### PR TITLE
Branch 7.x-1.13.3 mirror and PostreSQL fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ modules/contrib
 modules/nucivic
 themes/contrib
 webroot
+vendor
 test/vendor
 test/bin
 test/assets
@@ -12,8 +13,10 @@ test/dkan
 test/local.yml
 assets/*
 .idea
+*.iml
 behat.local.yml
 npm-debug.log
 .sublime-workspace
 docs/_build
 *.orig
+composer.lock

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,7 @@
 7.x-1.13.3
 ----------
- - #1859 Fixe update hooks to correctly set jquery version and remove old modified source date field
+ - #1864 Update media to 2.0 and remove patch 2534724. 
+ - #1859 Fixed update hooks to correctly set jquery version and remove old modified source date field
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,11 +2,11 @@
 ----------
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
- - #1821 Remove redundant CSS load in dkan_dataset
+ - #1821 Remove redundant CSS load in dkan_dataset.
  - #1726 Fixed broken links in search results to nodes without aliases
  - #1792 Remove Windows reserved characters from default content filenames for better Windows support
  - #1815 Support importing Temporal Coverage during POD Harvest.
- - #1785 Fix profile UI install.
+ - #1785 Fix error messages when installing DKAN with the UI.
  - #1786 Remove horizontal tab field from the group content type, fix margin on group block.
  - #1786 Add hook to auto-assign editors the og administrator role.
  - #1752 Added option for using quote delimiters when fast import is enabled for dkan datastore. Fixed error message when an import fails on DKAN Datastore Fast Import.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,4 +1,4 @@
-7.x-1.13.x
+7.x-1.13.3
 ----------
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
@@ -10,13 +10,13 @@
  - #1786 Remove horizontal tab field from the group content type, fix margin on group block.
  - #1786 Add hook to auto-assign editors the og administrator role.
  - #1752 Added option for using quote delimiters when fast import is enabled for dkan datastore. Fixed error message when an import fails on DKAN Datastore Fast Import.
- - #1703 Refactor Datastore API module, fixing some caching issues and improving joins 
+ - #1703 Refactor Datastore API module, fixing some caching issues and improving joins
  - #1804 Add project = dkan to dkan_sitewide.info to fix errors on update screen.
  - #1811 Apply patches to the rules module that can prevent unnecessary DB lockouts.
 
 7.x-1.13.2 2017-03-16
 ----------------------
- - #1803 Fix broken access to featured groups sort order view. 
+ - #1803 Fix broken access to featured groups sort order view.
  - #1796 Fix Harvest support for contact name and contact email.
  - #1795 Update front page test on topics.feature with @customizable.
  - #1783 Update services to 3.19

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,6 @@
 7.x-1.13.3
 ----------
+ - #1859 Fixe update hooks to correctly set jquery version and remove old modified source date field
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,7 +1,8 @@
 7.x-1.13.3
 ----------
- - #1864 Update media to 2.0 and remove patch 2534724. 
+ - #1863 Update restws module to v2.7
  - #1859 Fixed update hooks to correctly set jquery version and remove old modified source date field
+ - #1864 Update media to 2.0 and remove patch 2534724. 
  - #1829 Fixed missing properties on warning message during datajson harvest cache.
  - #1802 Better support for Issued and Updated dataset properties from harvested sources.
  - #1821 Remove redundant CSS load in dkan_dataset.

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,5 @@
-7.x-1.13.3
-----------
+7.x-1.13.3 2017-04-18
+---------------------
  - #1863 Update restws module to v2.7
  - #1859 Fixed update hooks to correctly set jquery version and remove old modified source date field
  - #1864 Update media to 2.0 and remove patch 2534724. 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,22 @@
+```
+ 2979  2017-05-01 07:37:51 git clone --branch 7.x-1.x https://github.com/NuCivic/dkan.git
+ 2991  2017-05-01 07:41:38 git tag -l
+ 2992  2017-05-01 07:42:18 git checkout tags/7.x-1.13.3
+ 2995  2017-05-01 07:43:18 composer require drush/drush
+ 2996  2017-05-01 07:43:48 drush make --prepare-install drupal-org-core.make webroot --yes
+ 2997  2017-05-01 07:51:25 rsync -av . webroot/profiles/dkan --exclude webroot
+ 2998  2017-05-01 07:51:48 drush -y make --no-core --contrib-destination=./ drupal-org.make webroot/profiles/dkan --no-recursion
+ 2999  2017-05-01 07:58:08 cd webroot/
+ 3008  2017-05-01 08:25:54 drush site-install dkan --notify --db-url="pgsql://dkan:odpvta2017@localhost/dkan_odp" | tee dkan_pgsql.log
+ 3012  2017-05-01 08:51:34 sudo service apache2 restart
+ 3013  2017-05-01 08:51:42 sudo service php5.6-fpm restart
+ 3017  2017-05-01 08:53:29 ps ax | grep -Ei "(php|apache|http|sql|java|python|bash)"
+ 3025  2017-05-01 09:01:57 sudo chown `whoami`.www-data webroot -R
+ 3026  2017-05-01 09:02:12 cd webroot/
+ 3027  2017-05-01 09:02:20 drush en radix
+ 3028  2017-05-01 09:03:09 drush radix "VTA Open Data" --kit=https://github.com/NuCivic/radix-kit-nuboot/archive/master.zip
+ 3029  2017-05-01 09:04:20 cp ../themes/nuboot_radix/assets/. sites/all/themes/vta_open_data/assets/ -vR
+ 3030  2017-05-01 09:05:28 mv sites/all/themes/vta_open_data/assets/js/nuboot_radix.script.js sites/all/themes/vta_open_data/assets/js/vta_open_data.script.js
+ 3032  2017-05-01 09:17:34 cp ~/SCVTA/dkan_mysql/webroot/sites/all/themes/vta_open_data/screenshot.png sites/all/themes/vta_open_data/ -v
+ 3033  2017-05-01 09:28:38 drush user-create VTA --mail="opendata@vta.org" --password="scvta"; drush user-add-role "administrator" VTA
+```

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "drush/drush": "^8.1"
+    }
+}

--- a/dkan.info
+++ b/dkan.info
@@ -124,3 +124,7 @@ dependencies[] = dkan_datastore
 dependencies[] = dkan_datastore_api
 dependencies[] = open_data_schema_map_dkan
 dependencies[] = visualization_entity_charts_dkan
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/dkan.install
+++ b/dkan.install
@@ -255,10 +255,19 @@ function dkan_update_7013() {
 /**
 * Drop the 'field_modified_source_date' field.
 */
-function dkan_dataset_update_7004() {
+function dkan_update_7014() {
   // Mark the field for deletion.
   field_delete_field('field_modified_source_date');
   // Run the batch process to actually delete the field.
   $batch_size = 1;
   field_purge_batch($batch_size);
+}
+
+/**
+ * Update the default jquery library to 1.10 (again).
+ */
+function dkan_update_7015() {
+  if (version_compare(variable_get('jquery_update_jquery_version'), '1.10', '<')) {
+    variable_set('jquery_update_jquery_version', '1.10');
+  }
 }

--- a/dkan.profile
+++ b/dkan.profile
@@ -419,7 +419,74 @@ function dkan_delete_markdown_buttons(&$context) {
  */
 function dkan_group_link_delete(&$context) {
   $context['message'] = t('Removing og_extra groups link');
-  db_query('DELETE FROM {menu_links} WHERE link_path = :link_path LIMIT 1', array(':link_path' => 'groups'));
+/**
+* @todo - FIX ME...
+```
+$ drush site-install dkan --db-url="pgsql://dkan:odpvta2017@localhost/dkan_odp" --notify | tee dkan_pgsql.log
+You are about to DROP all tables in your 'dkan_odp' database. Do you want to continue? (y/n): y
+Starting Drupal installation. This takes a while.                                                                                                                     [ok]
+Processed 3 (3 created, 0 updated, 0 failed, 0 ignored) in 0.9 sec (206/min) - done with 'dkan_default_content_groups'                                                [completed]
+Processed 18 (18 created, 0 updated, 0 failed, 0 ignored) in 3.6 sec (297/min) - done with 'dkan_default_content_resources'                                           [completed]
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Creating default object from empty value                                                                                                                              [error]
+File /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/modules/dkan/dkan_fixtures/includes/dataset.inc, line 103
+Processed 10 (0 created, 0 updated, 10 failed, 0 ignored) in 38.1 sec (16/min) - done with 'dkan_default_content_datasets'                                            [completed]
+Processed 18 (18 created, 0 updated, 0 failed, 0 ignored) in 1.2 sec (929/min) - done with 'dkan_default_content_visualization_entities'                              [completed]
+Processed 4 (4 created, 0 updated, 0 failed, 0 ignored) in 5.4 sec (44/min) - done with 'dkan_default_content_data_stories'                                           [completed]
+Processed 3 (3 created, 0 updated, 0 failed, 0 ignored) in 1.2 sec (151/min) - done with 'dkan_default_content_data_dashboards'                                       [completed]
+Processed 2 (2 created, 0 updated, 0 failed, 0 ignored) in 0.5 sec (252/min) - done with 'dkan_default_content_pages'                                                 [completed]
+exception 'PDOException' with message 'SQLSTATE[42601]: Syntax error: 7 ERROR:  syntax error at or near "LIMIT"                                                       [error]
+LINE 1: DELETE FROM menu_links WHERE link_path = 'groups' LIMIT 1
+                                                          ^' in /home/linuxwebexpert/SCVTA/dkan/webroot/includes/database/database.inc:2227
+Stack trace:
+#0 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/database/database.inc(2227): PDOStatement->execute(Array)
+#1 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/database/pgsql/database.inc(111): DatabaseStatementBase->execute(Array, Array)
+#2 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/database/database.inc(2406): DatabaseConnection_pgsql->query('DELETE FROM {me...', Array, Array)
+#3 /home/linuxwebexpert/SCVTA/dkan/webroot/profiles/dkan/dkan.profile(422): db_query('DELETE FROM {me...', Array)
+#4 [internal function]: dkan_group_link_delete(Array)
+#5 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/batch.inc(284): call_user_func_array('dkan_group_link...', Array)
+#6 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/form.inc(4714): _batch_process()
+#7 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/install.core.inc(444): batch_process('install.php?pro...', 'http://default/...')
+#8 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/install.core.inc(339): install_run_task(Array, Array)
+#9 /home/linuxwebexpert/SCVTA/dkan/webroot/includes/install.core.inc(77): install_run_tasks(Array)
+#10 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/includes/drush.inc(725): install_drupal(Array)
+#11 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/includes/drush.inc(711): drush_call_user_func_array('install_drupal', Array)
+#12 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/commands/core/drupal/site_install_7.inc(86): drush_op('install_drupal', Array)
+#13 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/commands/core/site_install.drush.inc(254): drush_core_site_install_version('dkan', Array)
+#14 [internal function]: drush_core_site_install('dkan')
+#15 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/includes/command.inc(422): call_user_func_array('drush_core_site...', Array)
+#16 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/includes/command.inc(231): _drush_invoke_hooks(Array, Array)
+#17 [internal function]: drush_command('dkan')
+#18 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/includes/command.inc(199): call_user_func_array('drush_command', Array)
+#19 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/lib/Drush/Boot/BaseBoot.php(67): drush_dispatch(Array)
+#20 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/includes/preflight.inc(66): Drush\Boot\BaseBoot->bootstrap_and_dispatch()
+#21 /home/linuxwebexpert/SCVTA/dkan/vendor/drush/drush/drush.php(12): drush_main()
+#22 {main}
+notify-send command failed. Please install it as per http://coderstalk.blogspot.com/2010/02/how-to-install-notify-send-in-ubuntu.html. Or you may specify an alternate[error]
+command to run by specifying --notify-cmd=<my_command>
+```
+*
+**/
+// For now...
+    return true;
+//  db_query('DELETE FROM {menu_links} WHERE link_path = :link_path LIMIT 1', array(':link_path' => 'groups'));
 }
 
 /**

--- a/docs/releases/notes/1.13.3.rst
+++ b/docs/releases/notes/1.13.3.rst
@@ -20,6 +20,10 @@ Improvements in this release
   - Inconsistencies in date fields (Harvest source "modified" vs Drupal's "modified" dates) were addressed by adding new fields to the *dataset* content type.
   - A bug preventing the "temporal coverage" field from being harvested was fixed.
 
+- The restws and media modules were updated to latest versions
+
+- Several other smaller bug fixes and improvements; see the CHANGELOG for more information.
+
 Special Notes
 -------------
 

--- a/docs/releases/notes/1.13.3.rst
+++ b/docs/releases/notes/1.13.3.rst
@@ -1,7 +1,24 @@
-DKAN 1.13.3 (future release)
-============================
+DKAN 1.13.3
+===========
 
-Placeholder for good things to come.
+This is a "patch" release of DKAN, containing bug fixes and minor updates, but adding no new functionality.
+
+Improvements in this release
+----------------------------
+
+- Groups permissions were given better logic. Editors will now become administrators of any group they are added to, giving them permission to edit or moderate any content in that group. Also, Site Manager was given permissions to edit the order of featured groups.
+
+- The order of groups on the front page and groups page was changed to alphabetical.
+
+- We now provide parsing options on the `Datastore Fast Import <http://docs.getdkan.com/en/latest/components/datastore.html#using-the-fast-import-option>`_. This means a user can set what delimiters and line terminators are used when importing a CSV file, avoiding some import errors users were experiencing.
+
+- Some errors were fixed that caused installing DKAN with the browser (using /install.php rather than drush). Also,  special characters were removed from default content filenames, fixing an installation bug on Windows systems.
+
+- Several bugs in the Harvest module were fixed:
+
+  - The Site Manager can now use the main dashboard view to initiate harvest actions in bulk
+  - Inconsistencies in date fields (Harvest source "modified" vs Drupal's "modified" dates) were addressed by adding new fields to the *dataset* content type.
+  - A bug preventing the "temporal coverage" field from being harvested was fixed.
 
 Special Notes
 -------------

--- a/docs/releases/notes/1.13.3.rst
+++ b/docs/releases/notes/1.13.3.rst
@@ -8,11 +8,11 @@ Improvements in this release
 
 - Groups permissions were given better logic. Editors will now become administrators of any group they are added to, giving them permission to edit or moderate any content in that group. Also, Site Manager was given permissions to edit the order of featured groups.
 
-- The order of groups on the front page and groups page was changed to alphabetical.
-
 - We now provide parsing options on the `Datastore Fast Import <http://docs.getdkan.com/en/latest/components/datastore.html#using-the-fast-import-option>`_. This means a user can set what delimiters and line terminators are used when importing a CSV file, avoiding some import errors users were experiencing.
 
 - Some errors were fixed that caused installing DKAN with the browser (using /install.php rather than drush). Also,  special characters were removed from default content filenames, fixing an installation bug on Windows systems.
+
+- The Rules module was patched to prevent a "cache rebuild lock" (see https://www.drupal.org/node/2851567)
 
 - Several bugs in the Harvest module were fixed:
 

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -299,7 +299,7 @@ projects:
      2406863: 'https://www.drupal.org/files/issues/rules-remove-cache-rebuild-log-2406863-21.patch'
      2851567: 'https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch'
   restws:
-    version: '2.6'
+    version: '2.7'
   roleassign:
     version: '1.1'
   safeword:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -1,32 +1,32 @@
+---
 api: '2'
 core: 7.x
 includes:
-  - "https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.1/visualization_entity.make"
-  - "https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make"
-  - "https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/master/leaflet_widget.make"
-  - "https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make"
+- https://raw.githubusercontent.com/NuCivic/visualization_entity/7.x-1.1/visualization_entity.make
+- https://raw.githubusercontent.com/NuCivic/open_data_schema_map/7.x-1.x/open_data_schema_map.make
+- https://raw.githubusercontent.com/NuCivic/leaflet_draw_widget/cb0d2b0e8c733a5f997038bd0b444ab2b6072542/leaflet_widget.make
+- https://raw.githubusercontent.com/NuCivic/recline/7.x-1.x/recline.make
 projects:
   admin_menu:
-    version: '3.0-rc5'
+    version: 3.0-rc5
   admin_menu_source:
     version: '1.1'
-    # Allow ordering of roles to handle users w/multiple roles
     patch:
-      2441283: 'https://www.drupal.org/files/issues/allow_ordering_of_the-2441283-5.patch'
+      2441283: https://www.drupal.org/files/issues/allow_ordering_of_the-2441283-5.patch
   adminrole:
     version: '1.1'
   autocomplete_deluxe:
     version: '2.2'
     patch:
-      2833824: 'https://www.drupal.org/files/issues/autocomplete-deluxe-2833824-4.patch'
+      2833824: https://www.drupal.org/files/issues/autocomplete-deluxe-2833824-4.patch
   beautytips:
     download:
       type: git
-      url: 'http://git.drupal.org/project/beautytips.git'
+      url: http://git.drupal.org/project/beautytips.git
       branch: 7.x-2.x
       revision: f9a8b5b
     patch:
-      849232: 'http://drupal.org/files/include-excanvas-via-libraries-api-d7-849232-13.patch'
+      849232: http://drupal.org/files/include-excanvas-via-libraries-api-d7-849232-13.patch
   better_exposed_filters:
     version: '3.4'
   bueditor:
@@ -36,16 +36,16 @@ projects:
   chosen:
     version: '2.0'
     patch:
-      2834096: 'https://www.drupal.org/files/issues/chosen-accesibility_problem_with_input-0.patch'
+      2834096: https://www.drupal.org/files/issues/chosen-accesibility_problem_with_input-0.patch
   colorizer:
     version: '1.10'
     patch:
-      2227651: 'https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch'
-      2599298: 'https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-9.patch'
+      2227651: https://www.drupal.org/files/issues/colorizer-add-rgb-vars-2227651-4b.patch
+      2599298: https://www.drupal.org/files/issues/colorizer-bug_system_cron_delete_current_css-2599298-9.patch
   color_field:
     version: '1.8'
     patch:
-      2696505: 'https://www.drupal.org/files/issues/color_field-requirements-2696505-v2.patch'
+      2696505: https://www.drupal.org/files/issues/color_field-requirements-2696505-v2.patch
   conditional_styles:
     version: '2.2'
   context:
@@ -53,11 +53,11 @@ projects:
   ctools:
     version: '1.12'
   data:
-    version: '1.x'
+    version: 1.x
   date:
     version: '2.9'
   defaultconfig:
-    version: '1.0-alpha11'
+    version: 1.0-alpha11
   diff:
     version: '3.2'
   double_field:
@@ -66,14 +66,14 @@ projects:
     version: '2.1'
   entity:
     download:
-      full_version: '7.x-1.8'
+      full_version: 7.x-1.8
     patch:
-      2341611: 'https://www.drupal.org/files/issues/entity-multivalue-token-replacement-fix-2341611-0.patch'
-      2564119: 'https://www.drupal.org/files/issues/Use-array-in-foreach-statement-2564119-1.patch'
+      2341611: https://www.drupal.org/files/issues/entity-multivalue-token-replacement-fix-2341611-0.patch
+      2564119: https://www.drupal.org/files/issues/Use-array-in-foreach-statement-2564119-1.patch
   entity_path:
-    version: '1.x-dev'
+    version: 1.x-dev
     patch:
-      2809655: 'https://www.drupal.org/files/issues/entity-path-mysql-5-7_3.diff'
+      2809655: https://www.drupal.org/files/issues/entity-path-mysql-5-7_3.diff
   entityreference:
     version: '1.2'
   entityreference_filter:
@@ -93,35 +93,35 @@ projects:
   feeds:
     download:
       type: git
-      url: 'http://git.drupal.org/project/feeds.git'
+      url: http://git.drupal.org/project/feeds.git
       branch: 7.x-2.x
       revision: 453dddfa5d8b2bc8c5961466490aa385f57655b2
     patch:
-      1428272: 'http://drupal.org/files/feeds-encoding_support_CSV-1428272-52.patch'
-      1127696: 'http://drupal.org/files/issues/1127696-97.patch'
+      1428272: http://drupal.org/files/feeds-encoding_support_CSV-1428272-52.patch
+      1127696: http://drupal.org/files/issues/1127696-97.patch
   feeds_field_fetcher:
     download:
       type: git
-      url: 'http://git.drupal.org/project/feeds_field_fetcher.git'
+      url: http://git.drupal.org/project/feeds_field_fetcher.git
       branch: 7.x-1.x
       revision: 6725b86
     patch:
-      2315425: 'http://www.drupal.org/files/issues/feeds_field_fetcher-typo-error-2315425-1.patch'
-      2829416: 'http://www.drupal.org/files/issues/feeds_field_fetcher_error-validation-config.patch'
+      2315425: http://www.drupal.org/files/issues/feeds_field_fetcher-typo-error-2315425-1.patch
+      2829416: http://www.drupal.org/files/issues/feeds_field_fetcher_error-validation-config.patch
   feeds_flatstore_processor:
     download:
       type: git
-      url: 'https://github.com/NuCivic/feeds_flatstore_processor.git'
-      branch: master
+      url: https://github.com/NuCivic/feeds_flatstore_processor.git
+      revision: 60ebdc5a688914b00f2f3ee15849a933acb5d751
   field_group:
     version: '1.5'
     patch:
-      2042681: 'http://drupal.org/files/issues/field-group-show-ajax-2042681-8.patch'
-      2831815: 'https://www.drupal.org/files/issues/hash-location-sanitization.diff'
+      2042681: http://drupal.org/files/issues/field-group-show-ajax-2042681-8.patch
+      2831815: https://www.drupal.org/files/issues/hash-location-sanitization.diff
   field_group_table:
     download:
       type: git
-      url: 'https://github.com/nuams/field_group_table.git'
+      url: https://github.com/nuams/field_group_table.git
       revision: 5b0aed9396a8cfd19a5b623a5952b3b8cacd361c
   field_hidden:
     version: '1.7'
@@ -131,39 +131,39 @@ projects:
   fieldable_panels_panes:
     version: '1.11'
     patch:
-      2825835: 'https://www.drupal.org/files/issues/2825835.patch'
-      2826182: 'https://www.drupal.org/files/issues/fieldable_panels_panes-title-shown-when-set-to-hidden-2826182-3.patch'
-      2826205: 'https://www.drupal.org/files/issues/fieldable_panels_panes-n2826205-32.patch'
+      2825835: https://www.drupal.org/files/issues/2825835.patch
+      2826182: https://www.drupal.org/files/issues/fieldable_panels_panes-title-shown-when-set-to-hidden-2826182-3.patch
+      2826205: https://www.drupal.org/files/issues/fieldable_panels_panes-n2826205-32.patch
   file_entity:
-    version: '2.0-beta3'
+    version: 2.0-beta3
     patch:
-      2308737: 'https://www.drupal.org/files/issues/file_entity-remove-field-status-check-2308737-9.patch'
+      2308737: https://www.drupal.org/files/issues/file_entity-remove-field-status-check-2308737-9.patch
   file_resup:
-    version: '1.x-dev'
+    version: 1.x-dev
   filefield_sources:
     version: '1.10'
   font_icon_select:
     download:
       type: git
-      url: 'https://git.drupal.org/sandbox/wolffereast/2319993.git'
+      url: https://git.drupal.org/sandbox/wolffereast/2319993.git
       branch: 7.x-1.x
   fontyourface:
     version: '2.8'
     patch:
       1: patches/fontyourface-no-ajax-browse-view.patch
       2: patches/fontyourface-clear-css-cache.patch
-      2644694: 'https://www.drupal.org/files/issues/browse-fonts-page-uses-disabled-font-2644694.patch'
-      2816837: 'https://www.drupal.org/files/issues/font_your_face-remove_div_general_text_option-D7.patch'
+      2644694: https://www.drupal.org/files/issues/browse-fonts-page-uses-disabled-font-2644694.patch
+      2816837: https://www.drupal.org/files/issues/font_your_face-remove_div_general_text_option-D7.patch
   globalredirect:
     version: '1.5'
   gravatar:
     download:
       type: git
-      url: 'http://git.drupal.org/project/gravatar.git'
+      url: http://git.drupal.org/project/gravatar.git
       branch: 7.x-1.x
       revision: bb2f81e
     patch:
-      1568162: 'http://drupal.org/files/views-display-user-picture-doesn-t-display-gravatar-1568162-10.patch'
+      1568162: http://drupal.org/files/views-display-user-picture-doesn-t-display-gravatar-1568162-10.patch
   honeypot:
     version: '1.22'
   image_url_formatter:
@@ -173,17 +173,17 @@ projects:
     type: module
     download:
       type: git
-      url: 'http://git.drupal.org/project/imagecache_actions.git'
+      url: http://git.drupal.org/project/imagecache_actions.git
       revision: cd19d2a
   job_scheduler:
-    version: '2.x'
+    version: 2.x
   jquery_update:
     version: '2.7'
   leaflet_draw_widget:
     download:
       type: git
-      url: 'https://github.com/NuCivic/leaflet_draw_widget.git'
-      branch: 'master'
+      url: https://github.com/NuCivic/leaflet_draw_widget.git
+      revision: cb0d2b0e8c733a5f997038bd0b444ab2b6072542
   libraries:
     version: '2.3'
   link:
@@ -199,7 +199,7 @@ projects:
   markdowneditor:
     version: '1.4'
     patch:
-      2045225: 'http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch'
+      2045225: http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch
   media:
     version: 2.0
     patch:
@@ -209,7 +209,7 @@ projects:
   media_vimeo:
     version: '2.1'
     patch:
-      2446199: 'https://www.drupal.org/files/issues/no_exception_handling-2446199-1.patch'
+      2446199: https://www.drupal.org/files/issues/no_exception_handling-2446199-1.patch
   menu_admin_per_menu:
     version: '1.1'
   menu_badges:
@@ -217,11 +217,11 @@ projects:
   menu_block:
     version: '2.7'
   menu_token:
-    version: '1.0-beta5'
+    version: 1.0-beta5
   migrate:
     version: '2.8'
     patch:
-      1989492: 'https://www.drupal.org/files/issues/migrate-append-map-messages-1989492-10.patch'
+      1989492: https://www.drupal.org/files/issues/migrate-append-map-messages-1989492-10.patch
   migrate_extras:
     version: '2.5'
   module_filter:
@@ -229,14 +229,14 @@ projects:
   multistep:
     download:
       type: git
-      url: 'http://git.drupal.org/project/multistep.git'
+      url: http://git.drupal.org/project/multistep.git
       revision: 3b0d40a
   og:
     version: '2.9'
     patch:
-      1090438: 'http://drupal.org/files/issues/og-add_users_and_entities_with_drush-1090438-12.patch'
-      2549071: 'https://www.drupal.org/files/issues/og_actions-bug-vbo-delete.patch'
-      2301831: 'https://www.drupal.org/files/issues/og-missing-permission-roles-2301831-1.patch'
+      1090438: http://drupal.org/files/issues/og-add_users_and_entities_with_drush-1090438-12.patch
+      2549071: https://www.drupal.org/files/issues/og_actions-bug-vbo-delete.patch
+      2301831: https://www.drupal.org/files/issues/og-missing-permission-roles-2301831-1.patch
   og_extras:
     version: '1.2'
   og_moderation:
@@ -244,8 +244,8 @@ projects:
   open_data_schema_map:
     download:
       type: git
-      url: 'https://github.com/NuCivic/open_data_schema_map.git'
-      branch: 7.x-1.x
+      url: https://github.com/NuCivic/open_data_schema_map.git
+      tag: 7.x-1.13.3
   panelizer:
     version: '3.4'
   panels:
@@ -274,30 +274,30 @@ projects:
   recline:
     download:
       type: git
-      url: 'https://github.com/NuCivic/recline.git'
-      branch: 7.x-1.x
+      url: https://github.com/NuCivic/recline.git
+      tag: 7.x-1.13.3
   ref_field:
     download:
       type: git
-      url: 'http://git.drupal.org/project/ref_field.git'
+      url: http://git.drupal.org/project/ref_field.git
       revision: 9dbf7cf
     patch:
-      2360019: 'https://www.drupal.org/files/issues/ref_field-delete-insert-warning-2360019-5.patch'
+      2360019: https://www.drupal.org/files/issues/ref_field-delete-insert-warning-2360019-5.patch
   remote_file_source:
-    version: '1.x'
+    version: 1.x
     patch:
-      2362487: 'https://www.drupal.org/files/issues/remote_file_source-location-content-dist_1.patch'
+      2362487: https://www.drupal.org/files/issues/remote_file_source-location-content-dist_1.patch
   remote_stream_wrapper:
-    version: '1.0-rc1'
+    version: 1.0-rc1
     patch:
-      2833837: 'https://www.drupal.org/files/issues/prevent-download-intent-open-stream-2833837-4.patch'
+      2833837: https://www.drupal.org/files/issues/prevent-download-intent-open-stream-2833837-4.patch
   role_export:
     version: '1.0'
   rules:
     version: '2.9'
     patch:
-     2406863: 'https://www.drupal.org/files/issues/rules-remove-cache-rebuild-log-2406863-21.patch'
-     2851567: 'https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch'
+      2406863: https://www.drupal.org/files/issues/rules-remove-cache-rebuild-log-2406863-21.patch
+      2851567: https://www.drupal.org/files/issues/rules_init_and_cache-2851567-8.patch
   restws:
     version: '2.7'
   roleassign:
@@ -326,19 +326,19 @@ projects:
   taxonomy_fixtures:
     download:
       type: git
-      url: 'https://github.com/NuCivic/taxonomy_fixtures.git'
-      branch: 7.x-1.x
+      url: https://github.com/NuCivic/taxonomy_fixtures.git
+      revision: 485d92019d11a61de585707db8f49d0160bd03b2
   token:
     version: '1.6'
   uuid:
-    version: '1.0-beta2'
+    version: 1.0-beta2
   views:
     version: '3.15'
   views_autocomplete_filters:
     version: '1.2'
     patch:
-      2374709: 'http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch'
-      2317351: 'http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch'
+      2374709: http://www.drupal.org/files/issues/views_autocomplete_filters-cache-2374709-2.patch
+      2317351: http://www.drupal.org/files/issues/views_autocomplete_filters-content-pane-2317351-4.patch
   views_bulk_operations:
     version: '3.3'
   views_responsive_grid:
@@ -356,52 +356,52 @@ projects:
   workbench_moderation:
     version: '3.0'
     patch:
-      2360973: 'https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch'
+      2360973: https://www.drupal.org/files/issues/workbench_moderation-install-warnings-2360973-3.patch
   drafty:
-    version: '1.0-beta3'
+    version: 1.0-beta3
 libraries:
   chosen:
     download:
       type: get
-      url: 'https://github.com/harvesthq/chosen/releases/download/v1.3.0/chosen_v1.3.0.zip'
+      url: https://github.com/harvesthq/chosen/releases/download/v1.3.0/chosen_v1.3.0.zip
   excanvas:
     download:
       type: git
-      url: 'https://github.com/arv/ExplorerCanvas.git'
+      url: https://github.com/arv/ExplorerCanvas.git
       sha1: aa989ea9d9bac748638f7c66b0fc88e619715da6
   font_awesome:
     type: libraries
     download:
       type: git
-      url: 'https://github.com/FortAwesome/Font-Awesome.git'
+      url: https://github.com/FortAwesome/Font-Awesome.git
       revision: 13d5dd373cbf3f2bddd8ac2ee8df3a1966a62d09
     directory_name: font_awesome
   jquery.imagesloaded:
     download:
       type: file
-      url: 'https://github.com/desandro/imagesloaded/archive/v2.1.2.tar.gz'
+      url: https://github.com/desandro/imagesloaded/archive/v2.1.2.tar.gz
       subtree: imagesloaded-2.1.2
   jquery.imgareaselect:
     download:
       type: file
-      url: 'https://github.com/odyniec/imgareaselect/archive/v0.9.11-rc.1.tar.gz'
+      url: https://github.com/odyniec/imgareaselect/archive/v0.9.11-rc.1.tar.gz
       subtree: imgareaselect-0.9.11-rc.1
   slugify:
     download:
       type: git
-      url: 'https://github.com/pmcelhaney/jQuery-Slugify-Plugin.git'
+      url: https://github.com/pmcelhaney/jQuery-Slugify-Plugin.git
       revision: 79133a1bdfd3ac80d500d661a722b85c03a01da3
     directory_name: slugify
   spectrum:
     download:
       type: git
-      url: 'https://github.com/NuCivic/spectrum.git'
+      url: https://github.com/NuCivic/spectrum.git
       tag: 1.8.0-civic-4736
     directory_name: bgrins-spectrum
   spyc:
     download:
       type: file
-      url: 'https://raw.github.com/mustangostang/spyc/master/Spyc.php'
+      url: https://raw.github.com/mustangostang/spyc/master/Spyc.php
     directory_name: spyc
 defaults:
   projects:

--- a/drupal-org.make
+++ b/drupal-org.make
@@ -201,10 +201,9 @@ projects:
     patch:
       2045225: 'http://drupal.org/files/remove-dsm-from-hook-install-2045225-1.patch'
   media:
-    version: '2.0-beta13'
+    version: 2.0
     patch:
-      2534724: 'https://www.drupal.org/files/issues/media-fix_rebuild_bug-2534724-105-d7.patch'
-      2272567: 'https://www.drupal.org/files/issues/media_dialog_appears_2272567-32.patch'
+      2272567: https://www.drupal.org/files/issues/media_dialog_appears_2272567-32.patch
   media_youtube:
     version: '3.0'
   media_vimeo:

--- a/modules/dkan/dkan_data_dashboard/dkan_data_dashboard.info
+++ b/modules/dkan/dkan_data_dashboard/dkan_data_dashboard.info
@@ -30,3 +30,7 @@ features[variable][] = panelizer_node:data_dashboard_default
 features[views_view][] = data_dashboards
 features[views_view][] = front_page_dashboards_list
 features_exclude[dependencies][dkan_topics] = dkan_topics
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_data_story/dkan_data_story.info
+++ b/modules/dkan/dkan_data_story/dkan_data_story.info
@@ -55,3 +55,7 @@ features_exclude[dependencies][image] = image
 features_exclude[dependencies][strongarm] = strongarm
 features_exclude[dependencies][taxonomy] = taxonomy
 no autodetect = 1
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_dataset/dkan_dataset.info
+++ b/modules/dkan/dkan_dataset/dkan_dataset.info
@@ -33,3 +33,7 @@ features[ctools][] = views:views_default:3.0
 features[features_api][] = api:2
 features[variable][] = pathauto_node_dataset_pattern
 features[variable][] = pathauto_node_resource_pattern
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_content_types/dkan_dataset_content_types.info
@@ -125,3 +125,7 @@ features_exclude[dependencies][og] = og
 features_exclude[dependencies][dkan_featured_topics] = dkan_featured_topics
 features_exclude[field_base][og_group_ref] = og_group_ref
 features_exclude[field_instance][node-dataset-og_group_ref] = node-dataset-og_group_ref
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.info
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_groups/dkan_dataset_groups.info
@@ -77,3 +77,7 @@ features[views_view][] = front_page_group_grid
 features[views_view][] = front_page_group_list
 features[views_view][] = group_block
 features[views_view][] = groups_page
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.info
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_rest_api/dkan_dataset_rest_api.info
@@ -10,3 +10,7 @@ features[ctools][] = services:services:3
 features[features_api][] = api:2
 features[services_endpoint][] = dkan_dataset_api
 mtime = 1417998121
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_dataset/modules/dkan_dataset_voting/dkan_dataset_voting.info
+++ b/modules/dkan/dkan_dataset/modules/dkan_dataset_voting/dkan_dataset_voting.info
@@ -17,3 +17,7 @@ features[field_instance][] = comment-comment_node_dataset-field_rating
 features[field_instance][] = node-dataset-field_rating
 features[variable][] = ajax_comments_node_types
 features[variable][] = ajax_comments_notify
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_datastore/dkan_datastore.info
+++ b/modules/dkan/dkan_datastore/dkan_datastore.info
@@ -22,3 +22,7 @@ features[views_view][] = datasets
 files[] = includes/Datastore.inc
 files[] = includes/DkanDatastore.inc
 files[] = includes/DkanDatastoreFastImport.inc
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.info
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_api/dkan_datastore_api.info
@@ -3,3 +3,7 @@ description = Access datastore info over json.
 package = DKAN API
 core = 7.x
 dependencies[] = services
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.info
+++ b/modules/dkan/dkan_datastore/modules/dkan_datastore_fast_import/dkan_datastore_fast_import.info
@@ -3,3 +3,7 @@ description = Enable fast import for resources
 core = 7.x
 package = DKAN
 dependencies[] = dkan_datastore
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_sitewide/dkan_sitewide.info
+++ b/modules/dkan/dkan_sitewide/dkan_sitewide.info
@@ -52,3 +52,7 @@ features[variable][] = user_picture_path
 features[variable][] = user_picture_style
 features[variable][] = user_pictures
 features[views_view][] = popular_tags
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panelizer/dkan_sitewide_panelizer.info
+++ b/modules/dkan/dkan_sitewide/modules/dkan_sitewide_panelizer/dkan_sitewide_panelizer.info
@@ -17,3 +17,7 @@ features[variable][] = panelizer_node:page_allowed_layouts_default
 features[variable][] = panelizer_node:page_allowed_types
 features[variable][] = panelizer_node:page_allowed_types_default
 features[variable][] = panelizer_node:page_default
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_topics/dkan_topics.info
+++ b/modules/dkan/dkan_topics/dkan_topics.info
@@ -57,3 +57,7 @@ features_exclude[dependencies][dkan_dataset_groups] = dkan_dataset_groups
 features_exclude[dependencies][dkan_topics] = dkan_topics
 no autodetect = 1
 project path = profiles/dkan/modules/dkan
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_topics/modules/dkan_default_topics/dkan_default_topics.info
+++ b/modules/dkan/dkan_topics/modules/dkan_default_topics/dkan_default_topics.info
@@ -5,3 +5,7 @@ package = DKAN Features
 dependencies[] = dkan_topics
 dependencies[] = taxonomy_fixtures
 dependencies[] = taxonomy
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/dkan_workflow/dkan_workflow.info
+++ b/modules/dkan/dkan_workflow/dkan_workflow.info
@@ -45,3 +45,7 @@ features[workbench_moderation_transitions][] = needs_review:published
 features[workbench_moderation_transitions][] = published:needs_review
 features_exclude[dependencies][ctools] = ctools
 features_exclude[dependencies][dkan_dataset_content_types] = dkan_dataset_content_types
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/open_data_federal_extras/open_data_federal_extras.info
+++ b/modules/dkan/open_data_federal_extras/open_data_federal_extras.info
@@ -27,3 +27,7 @@ features[field_instance][] = node-dataset-field_odfe_data_quality
 features[field_instance][] = node-dataset-field_odfe_investment_uii
 features[field_instance][] = node-dataset-field_odfe_program_code
 features[field_instance][] = node-dataset-field_odfe_system_of_records
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.info
+++ b/modules/dkan/open_data_schema_map_dkan/open_data_schema_map_dkan.info
@@ -21,3 +21,7 @@ features[open_data_schema_apis][] = data_json_1_1
 features[open_data_schema_apis][] = dcat_ap_v1_1_dataset
 features[open_data_schema_apis][] = dcat_v1_1
 features[open_data_schema_apis][] = dcat_v1_1_json
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan

--- a/themes/nuboot_radix/nuboot_radix.info
+++ b/themes/nuboot_radix/nuboot_radix.info
@@ -55,3 +55,7 @@ settings[toggle_favicon] = 1
 settings[toggle_main_menu] = 1
 settings[toggle_secondary_menu] = 1
 settings[copyright][format] = 'html'
+
+; Information added by DKAN release script on 4/18/2017
+version = 7.x-1.13.3
+project = dkan


### PR DESCRIPTION
Issue: DKAN installations fails for PostgreSQL

## Description

Stock DKAN repo fails to build PostgreSQL DB due to DKAN_Default_Content and Organic Groups Extras

## User story

Use DKAN with PostgreSQL and PostGIS for Open Data Portal

## How to reproduce

[Follow guidelines for installing DKAN](http://docs.getdkan.com/en/latest/introduction/installation.html)

## QA Steps

- [ ] Verify installation works per new INSTALL.md file

## Merge process

- No conflicts

## Reminders
- [ ] There is test for the issue.
- [ ] CHANGELOG updated.
- [ ] Coding standards checked.
- [ ] Review docs.getdkan.com (or in /docs) to see if it still covers the scope of the PR and update if needed.
